### PR TITLE
Refactor plugin logic

### DIFF
--- a/addons/group_shader/PluginMergedSprite.gd
+++ b/addons/group_shader/PluginMergedSprite.gd
@@ -5,13 +5,31 @@ onready var viewport: Viewport = $Viewport
 onready var merged_sprite: Sprite = $Sprite
 onready var viewport_sprites: Node2D = $Viewport/Sprites
 
+var plugin_tools = preload("res://addons/group_shader/plugin_tools.gd")
+
+var root_node: Node2D
+var signature: String
+
 func _ready():
 	viewport.size = Vector2(64, 64)
 	viewport.transparent_bg = true
 	viewport.render_target_v_flip = true
 	viewport.render_target_update_mode = Viewport.UPDATE_ALWAYS
 
-func merge_sprites(sprites: Array, bounds: Dictionary) -> void:
+func _process(delta):
+	if !is_instance_valid(root_node):
+		return
+
+	var sprites = plugin_tools.get_sprites(root_node)
+	var new_signature = plugin_tools.generate_node_signature(sprites)
+
+	if signature == new_signature:
+		return
+	
+	var bounds = plugin_tools.calculate_sprite_bounds(sprites)
+	
+	modify_sprite_material(root_node.material.duplicate())
+	
 	modify_viewport_bounds(bounds.size, -bounds.min)
 
 	modify_viewport_sprite_container(sprites)
@@ -43,16 +61,16 @@ func modify_viewport_sprite_container(new_sprites: Array) -> void:
 		viewport_sprites.add_child(clone_sprite(sprite))
 
 func clone_sprite(new_sprite: Sprite) -> Sprite:
-		var clone := Sprite.new()
+	var clone := Sprite.new()
 
-		clone.texture = new_sprite.texture
-		clone.scale = new_sprite.scale
-		clone.centered = new_sprite.centered
-		clone.rotation = new_sprite.rotation
-		clone.modulate = new_sprite.modulate
-		clone.region_enabled = new_sprite.region_enabled
-		clone.region_rect = new_sprite.region_rect
+	clone.texture = new_sprite.texture
+	clone.scale = new_sprite.scale
+	clone.centered = new_sprite.centered
+	clone.rotation = new_sprite.rotation
+	clone.modulate = new_sprite.modulate
+	clone.region_enabled = new_sprite.region_enabled
+	clone.region_rect = new_sprite.region_rect
 
-		clone.transform = new_sprite.get_global_transform()
-		
-		return clone
+	clone.transform = new_sprite.get_global_transform()
+	
+	return clone

--- a/addons/group_shader/plugin_ui.gd
+++ b/addons/group_shader/plugin_ui.gd
@@ -84,6 +84,7 @@ func make_checkbox(object) -> HBoxContainer:
 	# --- Checkbox
 	var cb = CheckBox.new()
 	cb.focus_mode = Control.FOCUS_NONE
+
 	cb.pressed = object.get_meta("merge_enabled", false)
 	cb.align = Label.ALIGN_LEFT
 	

--- a/demo/DemoScene.tscn
+++ b/demo/DemoScene.tscn
@@ -4,21 +4,59 @@
 [ext_resource path="res://demo/data/ObjectOutline.tres" type="Material" id=2]
 
 [node name="Node2D" type="Node2D"]
+__meta__ = {
+"merge_enabled": false
+}
 
 [node name="Node2D" type="Node2D" parent="."]
+__meta__ = {
+"merge_enabled": false
+}
 
 [node name="Icon" type="Sprite" parent="Node2D"]
 material = ExtResource( 2 )
-position = Vector2( 1.18921, -2.37842 )
+position = Vector2( -50.8502, -101.63 )
 texture = ExtResource( 1 )
 __meta__ = {
 "merge_enabled": false
 }
 
 [node name="Icon2" type="Sprite" parent="Node2D/Icon"]
-position = Vector2( 53.1058, 49.0084 )
+position = Vector2( 44.9163, 46.4886 )
+texture = ExtResource( 1 )
+
+[node name="Icon3" type="Sprite" parent="Node2D/Icon"]
+position = Vector2( 107.912, 193.269 )
+texture = ExtResource( 1 )
+
+[node name="Icon4" type="Sprite" parent="Node2D/Icon"]
+position = Vector2( -5.48058, 108.855 )
 texture = ExtResource( 1 )
 
 [node name="Icon" type="Sprite" parent="Node2D/Icon"]
 position = Vector2( -65.1128, 67.6635 )
+texture = ExtResource( 1 )
+
+[node name="Icon2" type="Sprite" parent="Node2D"]
+material = ExtResource( 2 )
+position = Vector2( -365.383, -38.5487 )
+texture = ExtResource( 1 )
+__meta__ = {
+"merge_enabled": false
+}
+
+[node name="Icon3" type="Sprite" parent="Node2D/Icon2"]
+position = Vector2( -151.109, 135.854 )
+texture = ExtResource( 1 )
+
+[node name="Icon4" type="Sprite" parent="Node2D/Icon2"]
+position = Vector2( -114.436, -34.1085 )
+texture = ExtResource( 1 )
+
+[node name="Icon5" type="Sprite" parent="Node2D/Icon2"]
+position = Vector2( -62.1277, 23.346 )
+texture = ExtResource( 1 )
+
+[node name="Icon6" type="Sprite" parent="Node2D/Icon2"]
+position = Vector2( 40.9814, 37.4178 )
 texture = ExtResource( 1 )


### PR DESCRIPTION
This commit fixes raised issues with the plugin logic workings:
 - Root node plugin effect history will be saved over engine restarts.
 - Plugin cleans up any leftovers either on disable or a restart.
 - Optimized plugin logic to let each merged sprite custom node handle their own processing.