### PR TITLE
Simplify root plugin script

### DIFF
--- a/addons/group_shader/plugin.gd
+++ b/addons/group_shader/plugin.gd
@@ -4,16 +4,15 @@ extends EditorPlugin
 var plugin_ui_reference = preload("res://addons/group_shader/plugin_ui.gd")
 var plugin_ui
 
-var tracked_nodes: Dictionary = {}
+var plugin_track_reference = preload("res://addons/group_shader/plugin_track.gd")
+var plugin_track
 
-var plugin_node_reference = preload("res://addons/group_shader/PluginMergedSprite.tscn")
-
-var current_root
+var plugin_clean_reference = preload("res://addons/group_shader/plugin_clean.gd")
+var plugin_clean
 
 # Plugin activation
 func _enter_tree() -> void:
-	plugin_ui = plugin_ui_reference.new()
-	plugin_ui.plugin = self
+	initialize_plugin()
 	
 	add_inspector_plugin(plugin_ui)
 	
@@ -23,64 +22,21 @@ func _enter_tree() -> void:
 func _exit_tree() -> void:
 	remove_inspector_plugin(plugin_ui)
 	
-	for node in tracked_nodes:
-		cleanup_tracked_node(node)
+	plugin_clean.cleanup()
 
 # On manual plugin disable remove any leftover traces of the plugin. 
-func disable_plugin():
-	for node in tracked_nodes.keys():
-		node.set_meta("merge_enabled", null)
+func disable_plugin() -> void:
+	plugin_clean.cleanup_meta()
 
-func process_plugin():
-	var new_root = get_editor_interface().get_edited_scene_root()
-	if !new_root || new_root == current_root:
-		return
+func process_plugin() -> void:
+	plugin_track.restore_tracking()
 
-	current_root = new_root
+func initialize_plugin() -> void:
+	plugin_ui = plugin_ui_reference.new()
+	plugin_ui.plugin_script = self
 	
-	restore_tracking(current_root)
-
-func restore_tracking(root):
-	if !(root is Node2D):
-		return
+	plugin_track = plugin_track_reference.new()
+	plugin_track.plugin_script = self
 	
-	if root.has_meta("merge_enabled") and root.get_meta("merge_enabled"):
-		add_tracking(root)
-
-	for child in root.get_children():
-		restore_tracking(child)
-
-# `add_tracking` starts tracking a new node, which needs a merged sprite.
-func add_tracking(node) -> void:
-	# For each new tracked node create a seperate plugin node, which will display
-	# the merged sprite. Each plugin node will have a reference to the node it is
-	# merging in its name.
-	var new_plugin_node = plugin_node_reference.instance()
-	new_plugin_node.name = "%sMergedSprite" % node.name
-	new_plugin_node.root_node = node
-	
-	# Add the new node so that the merged sprite and the original sprite
-	# can be siblings with the merged sprite being on top.
-	node.get_parent().add_child(new_plugin_node)
-	
-	tracked_nodes[node] = new_plugin_node
-
-func remove_tracking(node) -> void:
-	cleanup_tracked_node(node)
-
-func cleanup_tracked_node(node) -> void:
-	cleanup_plugin_node(node)
-
-	for child in node.get_parent().get_children():
-		if !child.name.begins_with("%sMergedSprite" % node.name):
-			continue
-		child.queue_free()
-		
-	tracked_nodes.erase(node)
-
-func cleanup_plugin_node(node) -> void:
-	var plugin_node = tracked_nodes[node]
-	
-	if !is_instance_valid(plugin_node):
-		return
-	plugin_node.queue_free()
+	plugin_clean = plugin_clean_reference.new()
+	plugin_clean.plugin_script = self

--- a/addons/group_shader/plugin_clean.gd
+++ b/addons/group_shader/plugin_clean.gd
@@ -1,0 +1,36 @@
+tool
+extends EditorPlugin
+
+var plugin_script
+
+var tracked_nodes
+
+func cleanup() -> void:
+	tracked_nodes = plugin_script.plugin_track.get_tracked_nodes()
+	
+	for node in tracked_nodes:
+		cleanup_tracked_node(node)
+
+func cleanup_tracked_node(node) -> void:
+	cleanup_plugin_node(tracked_nodes[node])
+
+	for child in node.get_parent().get_children():
+		if !child.name.begins_with("%sMergedSprite" % node.name):
+			continue
+		child.queue_free()
+
+func cleanup_plugin_node(new_plugin_node) -> void:
+	if !is_instance_valid(new_plugin_node):
+		return
+	new_plugin_node.queue_free()
+
+func cleanup_meta() -> void:
+	tracked_nodes = plugin_script.plugin_track.get_tracked_nodes()
+	
+	for node in tracked_nodes:
+		cleanup_node_meta(node)
+
+func cleanup_node_meta(new_node) -> void:
+	new_node.set_meta("merge_enabled", null)
+
+

--- a/addons/group_shader/plugin_track.gd
+++ b/addons/group_shader/plugin_track.gd
@@ -1,0 +1,52 @@
+tool
+extends EditorPlugin
+
+var plugin_script
+
+var plugin_node = preload("res://addons/group_shader/PluginMergedSprite.tscn")
+
+var tracked_nodes: Dictionary = {}
+
+var current_root
+
+func restore_tracking() -> void:
+	var new_root = get_editor_interface().get_edited_scene_root()
+	if !new_root || new_root == current_root:
+		return
+
+	current_root = new_root
+	
+	restore_node_tracking(current_root)
+
+func restore_node_tracking(root):
+	if !(root is Node2D):
+		return
+	
+	if root.has_meta("merge_enabled") and root.get_meta("merge_enabled"):
+		add_tracking(root)
+
+	for child in root.get_children():
+		restore_node_tracking(child)
+
+# `add_tracking` starts tracking a new node, which needs a merged sprite.
+func add_tracking(node) -> void:
+	# For each new tracked node create a seperate plugin node, which will display
+	# the merged sprite. Each plugin node will have a reference to the node it is
+	# merging in its name.
+	var new_plugin_node = plugin_node.instance()
+	new_plugin_node.name = "%sMergedSprite" % node.name
+	new_plugin_node.root_node = node
+	
+	# Add the new node so that the merged sprite and the original sprite
+	# can be siblings with the merged sprite being on top.
+	node.get_parent().add_child(new_plugin_node)
+	
+	tracked_nodes[node] = new_plugin_node
+
+func remove_tracking(node) -> void:
+	plugin_script.plugin_clean.cleanup_tracked_node(node)
+
+	tracked_nodes.erase(node)
+
+func get_tracked_nodes() -> Dictionary:
+	return plugin_script.plugin_track.tracked_nodes

--- a/addons/group_shader/plugin_ui.gd
+++ b/addons/group_shader/plugin_ui.gd
@@ -1,7 +1,7 @@
 tool
 extends EditorInspectorPlugin
 
-var plugin
+var plugin_script
 
 var inspected_nodes := {}
 
@@ -12,7 +12,7 @@ func parse_begin(object):
 	if inspected_nodes.has(object):
 		return
 	inspected_nodes[object] = true
-	
+
 	var header = make_header()
 
 	add_custom_control(header)
@@ -111,9 +111,9 @@ func handle_checkbox_toggle(status: bool, node):
 	node.set_meta("merge_enabled", status)
 
 	if status:
-		plugin.add_tracking(node)
+		plugin_script.plugin_track.add_tracking(node)
 	else:
-		plugin.remove_tracking(node)
+		plugin_script.plugin_track.remove_tracking(node)
 
 func _update_on_label(pressed: bool, on_label: Label) -> void:
 	# Fake inspector accent color: light blue

--- a/demo/DemoScene.tscn
+++ b/demo/DemoScene.tscn
@@ -15,10 +15,9 @@ __meta__ = {
 
 [node name="Icon" type="Sprite" parent="Node2D"]
 material = ExtResource( 2 )
-position = Vector2( -50.8502, -101.63 )
 texture = ExtResource( 1 )
 __meta__ = {
-"merge_enabled": false
+"merge_enabled": true
 }
 
 [node name="Icon2" type="Sprite" parent="Node2D/Icon"]
@@ -35,28 +34,4 @@ texture = ExtResource( 1 )
 
 [node name="Icon" type="Sprite" parent="Node2D/Icon"]
 position = Vector2( -65.1128, 67.6635 )
-texture = ExtResource( 1 )
-
-[node name="Icon2" type="Sprite" parent="Node2D"]
-material = ExtResource( 2 )
-position = Vector2( -365.383, -38.5487 )
-texture = ExtResource( 1 )
-__meta__ = {
-"merge_enabled": false
-}
-
-[node name="Icon3" type="Sprite" parent="Node2D/Icon2"]
-position = Vector2( -151.109, 135.854 )
-texture = ExtResource( 1 )
-
-[node name="Icon4" type="Sprite" parent="Node2D/Icon2"]
-position = Vector2( -114.436, -34.1085 )
-texture = ExtResource( 1 )
-
-[node name="Icon5" type="Sprite" parent="Node2D/Icon2"]
-position = Vector2( -62.1277, 23.346 )
-texture = ExtResource( 1 )
-
-[node name="Icon6" type="Sprite" parent="Node2D/Icon2"]
-position = Vector2( 40.9814, 37.4178 )
 texture = ExtResource( 1 )


### PR DESCRIPTION
This commit removes out of place code logic form the root plugin script. Code has been restructured into:
 - plugin_track - which stores tracking related logic and methods.
 - plugin_clean - which stores cleaning related methods.
 - plugin_ui - which handles plugin ui logic.
 - plugin_tools - which stores static abstract tools for the plugin.